### PR TITLE
Add output handler to print list of strings

### DIFF
--- a/pyqi/core/interfaces/optparse/__init__.py
+++ b/pyqi/core/interfaces/optparse/__init__.py
@@ -144,9 +144,9 @@ class OptparseInterface(Interface):
         # Instantiate the command line parser object
         parser = OptionParser(usage=usage, version=version)
 
-        # If no arguments were provided, print the help string (unless the
-        # caller specified not to).
-        if self.HelpOnNoArguments and len(in_) == 0:
+        # If the command has required options and no input arguments were
+        # provided, print the help string.
+        if len(required_opts) > 0 and self.HelpOnNoArguments and len(in_) == 0:
             parser.print_usage()
             return parser.exit(-1)
 

--- a/pyqi/core/interfaces/optparse/output_handler.py
+++ b/pyqi/core/interfaces/optparse/output_handler.py
@@ -63,3 +63,11 @@ def write_list_of_strings(result_key, data, option_value=None):
     with open(option_value, 'w') as f:
         f.write('\n'.join(data))
         f.write('\n')
+
+def print_list_of_strings(result_key, data, option_value=None):
+    """Print a list of strings to stdout, one per line.
+
+    ``result_key`` and ``option_value`` are ignored.
+    """
+    for line in data:
+        print line

--- a/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
@@ -17,15 +17,17 @@ __version__ = "0.1-dev"
 __maintainer__ = "Daniel McDonald"
 __email__ = "mcdonadt@colorado.edu"
 
-from tempfile import mkdtemp
+import os
+import sys
+from StringIO import StringIO
 from shutil import rmtree
+from tempfile import mkdtemp
 from unittest import TestCase, main
 from pyqi.core.interfaces.optparse.output_handler import (write_string,
-        write_list_of_strings)
+        write_list_of_strings, print_list_of_strings)
 from pyqi.core.exception import IncompetentDeveloperError
-import os
 
-class CLIOutputHandlerTests(TestCase):
+class OutputHandlerTests(TestCase):
     def setUp(self):
         self.output_dir = mkdtemp()
         self.fp = os.path.join(self.output_dir, 'test_file.txt')
@@ -34,6 +36,7 @@ class CLIOutputHandlerTests(TestCase):
         rmtree(self.output_dir)
 
     def test_write_string(self):
+        """Correctly writes a string to file."""
         # can't write without a path
         self.assertRaises(IncompetentDeveloperError, write_string, 'a','b')
 
@@ -44,6 +47,7 @@ class CLIOutputHandlerTests(TestCase):
         self.assertEqual(obs, 'bar\n')
 
     def test_write_list_of_strings(self):
+        """Correctly writes a list of strings to file."""
         # can't write without a path
         self.assertRaises(IncompetentDeveloperError, write_list_of_strings,
                           'a', ['b', 'c'])
@@ -53,6 +57,24 @@ class CLIOutputHandlerTests(TestCase):
             obs = obs_f.read()
 
         self.assertEqual(obs, 'bar\nbaz\n')
+
+    def test_print_list_of_strings(self):
+        """Correctly prints a list of strings."""
+        # Save stdout and replace it with something that will capture the print
+        # statement. Note: this code was taken from here:
+        # http://stackoverflow.com/questions/4219717/how-to-assert-output-
+        #     with-nosetest-unittest-in-python/4220278#4220278
+        saved_stdout = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            print_list_of_strings('this is ignored', ['foo', 'bar', 'baz'])
+
+            exp = 'foo\nbar\nbaz\n'
+            obs = out.getvalue()
+            self.assertEqual(obs, exp)
+        finally:
+            sys.stdout = saved_stdout
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Necessary for print_biom_python_config.py.

Also fix optparse code to allow for commands that have no required options.
