### PR TITLE
Driver supports dashed and underscored command names

### DIFF
--- a/scripts/pyqi
+++ b/scripts/pyqi
@@ -20,7 +20,7 @@ __email__ = "mcdonadt@colorado.edu"
 import importlib
 import textwrap
 from sys import argv, exit, stderr
-from pyqi.core.interface import get_command_names
+from pyqi.core.interface import get_command_names, get_command_config
 from pyqi.core.interfaces.optparse import optparse_main, optparse_factory
 from os.path import basename
 from string import ljust 
@@ -36,7 +36,8 @@ def usage(cmd_cfg_mod, command_names):
     valid_cmds = []
     invalid_cmds = []
     for c in command_names:
-        cmd_cfg, error_msg = get_cmd_cfg(cmd_cfg_mod, c, exit_on_failure=False)
+        cmd_cfg, error_msg = get_command_config(cmd_cfg_mod, c,
+                                                exit_on_failure=False)
 
         if cmd_cfg is None:
             invalid_cmds.append((c, error_msg))
@@ -71,28 +72,9 @@ def usage(cmd_cfg_mod, command_names):
     print "See '%s help <command>' for more information on a specific command." % argv[0]
     exit(0)
 
-def get_cmd_cfg(cmd_cfg_mod, cmd, exit_on_failure=True):
-    """Get the configuration for a ``Command``"""
-    cmd_cfg = None
-    error_msg = None
-
-    try:
-        cmd_cfg = importlib.import_module('.'.join([cmd_cfg_mod, cmd]))
-    except ImportError, e:
-        error_msg = str(e)
-
-        if exit_on_failure:
-            stderr.write("Unable to import the command configuration for "
-                         "%s:\n" % cmd)
-            stderr.write(error_msg)
-            stderr.write('\n')
-            exit(1)
-
-    return cmd_cfg, error_msg
-
 def get_cmd_obj(cmd_cfg_mod, cmd):
     """Get a ``Command`` object"""
-    cmd_cfg, _ = get_cmd_cfg(cmd_cfg_mod, cmd)
+    cmd_cfg, _ = get_command_config(cmd_cfg_mod, cmd)
     return optparse_factory(cmd_cfg.CommandConstructor, cmd_cfg.usage_examples, 
                             cmd_cfg.inputs, cmd_cfg.outputs)
 
@@ -113,6 +95,7 @@ def assert_command_exists(command_name, command_names, driver_name):
                                              "command:", TERM_WIDTH))
         stderr.write("%s\n\n%s%s\n\n" % (error_msg, ' ' * INDENT, driver_name))
         exit(1)
+
 
 if __name__ == '__main__':
     driver_name = 'pyqi'

--- a/tests/test_commands/test_make_bash_completion.py
+++ b/tests/test_commands/test_make_bash_completion.py
@@ -11,10 +11,7 @@
 from __future__ import division
 from unittest import TestCase, main
 import pyqi
-from pyqi.commands.make_bash_completion import (BashCompletion,
-                                                _get_cfg_module, _load_cfg)
-from pyqi.interfaces.optparse.config.make_bash_completion import (inputs,
-                                                                  outputs)
+from pyqi.commands.make_bash_completion import BashCompletion, _get_cfg_module
 
 __author__ = "Daniel McDonald"
 __copyright__ = "Copyright 2013, The pyqi project"
@@ -28,12 +25,6 @@ class BashCompletionTests(TestCase):
     def test_get_cfg_module(self):
         self.assertEqual(_get_cfg_module('pyqi'), pyqi)
 
-    def test_load_cfg(self):
-        i, o = _load_cfg('pyqi.interfaces.optparse.config',
-                         'make_bash_completion')
-        self.assertEqual(i, inputs)
-        self.assertEqual(o, outputs)
-    
     def test_init(self):
         obj = BashCompletion()
 

--- a/tests/test_core/test_interface.py
+++ b/tests/test_core/test_interface.py
@@ -19,18 +19,34 @@ __maintainer__ = "Jai Ram Rideout"
 __email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
-from pyqi.core.interface import get_command_names
+from pyqi.core.interface import get_command_names, get_command_config
+import pyqi.interfaces.optparse.config.make_bash_completion
 
 class TopLevelTests(TestCase):
     def test_get_command_names(self):
         """Test that command names are returned from a config directory."""
-        exp = ['make_bash_completion', 'make_command', 'make_optparse']
+        exp = ['make-bash-completion', 'make-command', 'make-optparse']
         obs = get_command_names('pyqi.interfaces.optparse.config')
         self.assertEqual(obs, exp)
 
         # Invalid config dir.
         with self.assertRaises(ImportError):
             _ = get_command_names('foo.bar.baz-aar')
+
+    def test_get_command_config(self):
+        """Test successful and unsuccessful module loading."""
+        cmd_cfg, error_msg = get_command_config(
+                'pyqi.interfaces.optparse.config', 'make_bash_completion')
+        self.assertEqual(cmd_cfg,
+                         pyqi.interfaces.optparse.config.make_bash_completion)
+        self.assertEqual(error_msg, None)
+
+        cmd_cfg, error_msg = get_command_config(
+                'hopefully.nonexistent.python.module', 'umm',
+                exit_on_failure=False)
+        self.assertEqual(cmd_cfg, None)
+        self.assertEqual(error_msg, 'No module named hopefully.nonexistent.'
+                                    'python.module.umm')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The driver shows dashed command names when it displays all commands that it knows about, but it will accept either dashed or underscored command names as input.

Bash completion autocompletes dashed names (to avoid always having an ambiguous name to tab complete). Bash completion will only be created for commands that can be imported/loaded successfully.

Fixes #130.
