### PR TITLE
Fix test_make_bash_completion

### DIFF
--- a/tests/test_commands/test_make_bash_completion.py
+++ b/tests/test_commands/test_make_bash_completion.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import division
 
 #-----------------------------------------------------------------------------
 # Copyright (c) 2013, The BiPy Development Team.
@@ -8,35 +9,81 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import division
+import sys
+from os import mkdir
+from os.path import dirname, join
+from shutil import copy, rmtree
+from tempfile import mkdtemp
 from unittest import TestCase, main
 import pyqi
 from pyqi.commands.make_bash_completion import BashCompletion, _get_cfg_module
 
 __author__ = "Daniel McDonald"
 __copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+               "Greg Caporaso"]
 __license__ = "BSD"
 __version__ = "0.1.0-dev"
 __maintainer__ = "Daniel McDonald"
 __email__ = "mcdonadt@colorado.edu"
 
 class BashCompletionTests(TestCase):
+    def setUp(self):
+        """Set up data for unit tests."""
+        self.cmd = BashCompletion()
+
+        # Create a temporary directory that we can copy two config files into.
+        # This module can then be passed to BashCompletion so that we don't
+        # have to update the expected output each time we make an interface
+        # change to pyqi. The temporary directory/module structure looks like
+        # the following:
+        #
+        #     <temp dir>/
+        #         pyqi_test/
+        #             __init__.py
+        #             make_bash_completion.py
+        #             make_optparse.py
+        #
+        # Note that <temp dir> is added to sys.path in setUp and then removed
+        # in tearDown. Imports can then function as normal, e.g.:
+        #
+        #     import pyqi_test.make_bash_completion
+        #     ...
+        #
+        self.temp_module_dir = mkdtemp()
+        self.temp_module_name = 'pyqi_test'
+        self.temp_config_dir = join(self.temp_module_dir,
+                                    self.temp_module_name)
+        mkdir(self.temp_config_dir)
+
+        module = _get_cfg_module('pyqi.interfaces.optparse.config')
+        module_dir = dirname(module.__file__)
+
+        make_bash_completion_fp = join(module_dir, 'make_bash_completion.py')
+        copy(make_bash_completion_fp, self.temp_config_dir)
+
+        make_optparse_fp = join(module_dir, 'make_optparse.py')
+        copy(make_optparse_fp, self.temp_config_dir)
+
+        with open(join(self.temp_config_dir, '__init__.py'), 'w') as f:
+            f.write('')
+
+        sys.path.append(self.temp_module_dir)
+
+    def tearDown(self):
+        sys.path.remove(self.temp_module_dir)
+        rmtree(self.temp_module_dir)
+
     def test_get_cfg_module(self):
         self.assertEqual(_get_cfg_module('pyqi'), pyqi)
 
-    def test_init(self):
-        obj = BashCompletion()
-
     def test_run(self):
-        params = {'command_config_module':'pyqi.interfaces.optparse.config',
+        params = {'command_config_module':self.temp_module_name,
                   'driver_name':'pyqi'}
-        obs = BashCompletion().run(**params)
-        
-        # output is dependent on the commands and options, this is not a good
-        # test. 
-        #self.assertEqual(obs, {'result':outputandstuff})    
-        self.fail("need more sane test that is independent of changes in commands/options")
+        obs = self.cmd(**params)
+        self.assertEqual(obs.keys(), ['result'])
+        self.assertEqual(obs['result'], outputandstuff)
+
 
 outputandstuff = """_pyqi_complete()
 {
@@ -51,16 +98,13 @@ outputandstuff = """_pyqi_complete()
   fi  
 
   if [ $COMP_CWORD -eq 1 ]; then
-    COMPREPLY=( $(compgen -W "make_bash_completion make_command make_optparse" -- $cur) )
+    COMPREPLY=( $(compgen -W "make-bash-completion make-optparse" -- $cur) )
   elif [ $COMP_CWORD -gt 1 ]; then
     case "$prev" in
-             "make_bash_completion")
+             "make-bash-completion")
         COMPREPLY=( $(compgen -W "--command-config-module --driver-name --output-fp" -- $cur) )
         ;;
-       "make_command")
-        COMPREPLY=( $(compgen -W "--author --command-version --copyright --credits --email --license --name --output-fp" -- $cur) )
-        ;;
-       "make_optparse")
+       "make-optparse")
         COMPREPLY=( $(compgen -W "--command --command-module --output-fp" -- $cur) )
         ;;
 
@@ -73,6 +117,7 @@ outputandstuff = """_pyqi_complete()
 } &&
 complete -F _pyqi_complete -f pyqi
 """
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_commands/test_make_optparse.py
+++ b/tests/test_commands/test_make_optparse.py
@@ -41,7 +41,6 @@ class MakeOptparseTests(TestCase):
 
         obs = obj.run(**{'command_module':'foobar', 'command':stubby()})
         
-        print obs['result']
         self.assertEqual(obs['result'], exp) 
 
 win_text = """#!/usr/bin/env python


### PR DESCRIPTION
test_make_bash_completion now creates a temporary config directory with two config files. This makes the unit tests more maintainable as the pyqi project continues to grow.

Fixes #116.
