### PR TITLE
add 2to3 conversion in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from glob import glob
 try:
     # python 3.x
     from distutils.command.build_py import build_py_2to3 as build_py
-except:
+except ImportError:
     # python 2.x
     from distutils.command.build_py import build_py
 


### PR DESCRIPTION
Based on [2to3 docs](https://wiki.python.org/moin/PortingPythonToPy3k), using approach 1
