### PR TITLE
added dry_run parameter. fixes #207

### DIFF
--- a/pyqi/util.py
+++ b/pyqi/util.py
@@ -24,30 +24,35 @@ from sys import stdout, stderr
 from subprocess import Popen, PIPE, STDOUT
 from pyqi.core.log import StdErrLogger
 
-def pyqi_system_call(cmd, shell=True):
+def pyqi_system_call(cmd, shell=True, dry_run=False):
     """Call cmd and return (stdout, stderr, return_value).
 
-    cmd can be either a string containing the command to be run, or a sequence
-    of strings that are the tokens of the command.
-
-    Please see Python's subprocess.Popen for a description of the shell
-    parameter and how cmd is interpreted differently based on its value.
+    cmd: can be either a string containing the command to be run, or a 
+     sequence of strings that are the tokens of the command.
+    shell: value passed directly to Popen (default: True). See Python's 
+     subprocess.Popen for a description of the shell parameter and how cmd
+     is interpreted differently based on its value.
+    dry_run: if True, print cmd and return ("", "", 0) (default: False)
     
     This function is ported from QIIME (http://www.qiime.org), previously
     named qiime_system_call. QIIME is a GPL project, but we obtained permission
     from the authors of this function to port it to pyqi (and keep it under
     pyqi's BSD license).
     """
-    proc = Popen(cmd,
-                 shell=shell,
-                 universal_newlines=True,
-                 stdout=PIPE,
-                 stderr=PIPE)
-    # communicate pulls all stdout/stderr from the PIPEs to 
-    # avoid blocking -- don't remove this line!
-    stdout, stderr = proc.communicate()
-    return_value = proc.returncode
-    return stdout, stderr, return_value
+    if dry_run:
+        print cmd
+        return "", "", 0
+    else:
+        proc = Popen(cmd,
+                     shell=shell,
+                     universal_newlines=True,
+                     stdout=PIPE,
+                     stderr=PIPE)
+        # communicate pulls all stdout/stderr from the PIPEs to 
+        # avoid blocking -- don't remove this line!
+        stdout, stderr = proc.communicate()
+        return_value = proc.returncode
+        return stdout, stderr, return_value
 
 def remove_files(list_of_filepaths, error_on_missing=True):
     """Remove list of filepaths, optionally raising an error if any are missing


### PR DESCRIPTION
```
>>> from pyqi.util import pyqi_system_call

>>> pyqi_system_call('ls -la')
('total 64\ndrwxr-xr-x   16 caporaso  staff    544 Dec  2 11:32 .\ndrwxr-xr-x  310 caporaso  staff  10540 Dec  2 10:13 ..\ndrwxr-xr-x   16 caporaso  staff    544 Dec  2 11:40 .git\n-rw-r--r--    1 caporaso  staff     54 Aug  3 13:25 .gitattributes\n-rw-r--r--    1 caporaso  staff    265 Aug 26 12:59 .gitignore\n-rw-r--r--@   1 caporaso  staff   2071 Aug 26 12:59 COPYING.txt\n-rw-r--r--    1 caporaso  staff    232 Dec  2 11:32 ChangeLog.md\n-rw-r--r--    1 caporaso  staff    177 Oct 30 11:29 MANIFEST.in\n-rw-r--r--@   1 caporaso  staff   1260 Aug 26 12:59 README.md\ndrwxr-xr-x    4 caporaso  staff    136 Aug  4 13:48 build\ndrwxr-xr-x   11 caporaso  staff    374 Oct  4 10:11 doc\ndrwxr-xr-x   12 caporaso  staff    408 Dec  2 11:41 pyqi\ndrwxr-xr-x    3 caporaso  staff    102 Oct  4 10:11 scripts\n-rw-r--r--    1 caporaso  staff   3246 Dec  2 11:32 setup.py\ndrwxr-xr-x    5 caporaso  staff    170 Aug  6 07:16 tests\n-rw-r--r--    1 caporaso  staff     67 Oct 30 11:29 tox.ini\n', '', 0)

>>> pyqi_system_call('ls -la',dry_run=True)
ls -la
('', '', 0)

>>>
```
