### PR TITLE
Modify script-level headers and header generator

### DIFF
--- a/pyqi/__init__.py
+++ b/pyqi/__init__.py
@@ -8,11 +8,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Rob Knight", "Greg Caporaso", "Daniel McDonald",
                "Jai Ram Rideout", "Doug Wendel"]
-__license__ = "BSD"
 __version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/commands/__init__.py
+++ b/pyqi/commands/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Greg Caporaso",
                "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"

--- a/pyqi/commands/code_header_generator.py
+++ b/pyqi/commands/code_header_generator.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Jai Ram Rideout", "Daniel McDonald"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
+__credits__ = ["Jai Ram Rideout", "Daniel McDonald", "Adam Robbins-Pianka"]
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, 
     ParameterCollection)
@@ -23,13 +17,7 @@ from pyqi.core.command import (Command, CommandIn, CommandOut,
 header_format = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "%(author)s"
-__copyright__ = "%(copyright)s"
 __credits__ = [%(credits)s]
-__license__ = "%(license)s"
-__version__ = "%(version)s"
-__maintainer__ = "%(author)s"
-__email__ = "%(email)s"
 """
 
 class CodeHeaderGenerator(Command):
@@ -40,20 +28,9 @@ class CodeHeaderGenerator(Command):
                        "the top of a Python file.")
 
     CommandIns = ParameterCollection([
-        CommandIn(Name='author', DataType=str,
-                  Description='author/maintainer name', Required=True),
-        CommandIn(Name='email', DataType=str,
-                  Description='maintainer email address', Required=True),
-        CommandIn(Name='license', DataType=str,
-                  Description='license (e.g., BSD)', Required=True),
-        CommandIn(Name='copyright', DataType=str,
-                  Description='copyright (e.g., Copyright 2013, The pyqi '
-                              'project)', Required=True),
-        CommandIn(Name='version', DataType=str,
-                  Description='version (e.g., 0.1)', Required=True),
         CommandIn(Name='credits', DataType=list,
-                  Description='list of other authors',
-                  Required=False, Default=None)
+                  Description='list of authors',
+                  Required=True, Default=None)
     ])
 
     CommandOuts = ParameterCollection([
@@ -63,18 +40,13 @@ class CodeHeaderGenerator(Command):
     def run(self, **kwargs):
         # Build a string formatting dictionary for the file header.
         head = {}
-        head['author']    = kwargs['author']
-        head['email']     = kwargs['email']
-        head['license']   = kwargs['license']
-        head['copyright'] = kwargs['copyright']
-        head['version']   = kwargs['version']
 
-        # Credits always includes author.
-        credits = [head['author']]
-        if kwargs['credits']:
-            credits.extend(kwargs['credits'])
+        credits = kwargs['credits']
 
-        f = lambda x: '"%s"' % x
+        def f(x):
+            """Returns a double-quoted version of input"""
+            return '"%s"' % x
+
         head['credits'] = ', '.join(map(f, credits))
 
         return {'result': (header_format % head).split('\n')}

--- a/pyqi/commands/make_bash_completion.py
+++ b/pyqi/commands/make_bash_completion.py
@@ -10,13 +10,8 @@
 
 from __future__ import division
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 import importlib
 from pyqi.core.command import (Command, CommandIn, CommandOut, 

--- a/pyqi/commands/make_command.py
+++ b/pyqi/commands/make_command.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, 
     ParameterCollection)
@@ -83,9 +77,7 @@ class MakeCommand(CodeHeaderGenerator):
 
     def run(self, **kwargs):
         code_header_lines = super(MakeCommand, self).run(
-                author=kwargs['author'], email=kwargs['email'],
-                license=kwargs['license'], copyright=kwargs['copyright'],
-                version=kwargs['version'], credits=kwargs['credits'])['result']
+                credits=kwargs['credits'])['result']
 
         result_lines = code_header_lines
 

--- a/pyqi/commands/make_optparse.py
+++ b/pyqi/commands/make_optparse.py
@@ -14,14 +14,8 @@ from pyqi.core.command import (Command, CommandIn, CommandOut,
     ParameterCollection)
 from pyqi.commands.code_header_generator import CodeHeaderGenerator
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Greg Caporaso",
                "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 header_format = """from pyqi.core.interfaces.optparse import (OptparseUsageExample,
                                            OptparseOption, OptparseResult)
@@ -135,9 +129,7 @@ class MakeOptparse(CodeHeaderGenerator):
 
     def run(self, **kwargs):
         code_header_lines = super(MakeOptparse, self).run(
-                author=kwargs['author'], email=kwargs['email'],
-                license=kwargs['license'], copyright=kwargs['copyright'],
-                version=kwargs['version'], credits=kwargs['credits'])['result']
+                credits=kwargs['credits'])['result']
 
         result_lines = code_header_lines
 

--- a/pyqi/commands/serve_html_interface.py
+++ b/pyqi/commands/serve_html_interface.py
@@ -10,13 +10,7 @@
 
 from __future__ import division
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, ParameterCollection)
 from pyqi.core.interfaces.html import start_server

--- a/pyqi/core/__init__.py
+++ b/pyqi/core/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/core/command.py
+++ b/pyqi/core/command.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import re
 from pyqi.core.log import NullLogger

--- a/pyqi/core/container.py
+++ b/pyqi/core/container.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 class ContainerError(Exception):
     pass

--- a/pyqi/core/exception.py
+++ b/pyqi/core/exception.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 class CommandError(Exception):
     pass

--- a/pyqi/core/factory.py
+++ b/pyqi/core/factory.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 def general_factory(command_constructor, usage_examples, inputs, outputs,
                     version, interface=None):

--- a/pyqi/core/interface.py
+++ b/pyqi/core/interface.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout", "Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import importlib
 from sys import exit, stderr

--- a/pyqi/core/interfaces/__init__.py
+++ b/pyqi/core/interfaces/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/core/interfaces/html/__init__.py
+++ b/pyqi/core/interfaces/html/__init__.py
@@ -8,13 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
+__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald",
+    "Greg Caporaso"]
 
 import os
 import types

--- a/pyqi/core/interfaces/html/input_handler.py
+++ b/pyqi/core/interfaces/html/input_handler.py
@@ -9,11 +9,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
 __version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
-

--- a/pyqi/core/interfaces/html/output_handler.py
+++ b/pyqi/core/interfaces/html/output_handler.py
@@ -9,13 +9,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
 __version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 def newline_list_of_strings(result_key, data, option_value=None):
     """Return a string from a list of strings while appending newline"""

--- a/pyqi/core/interfaces/optparse/__init__.py
+++ b/pyqi/core/interfaces/optparse/__init__.py
@@ -8,15 +8,9 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Gavin Huttley",
                "Rob Knight", "Doug Wendel", "Jai Ram Rideout",
                "Jose Antonio Navas Molina"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import os
 import types

--- a/pyqi/core/interfaces/optparse/input_handler.py
+++ b/pyqi/core/interfaces/optparse/input_handler.py
@@ -14,14 +14,8 @@ function(option_value)
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 def command_handler(option_value):
     """Dynamically load a Python object from a module and return an instance"""

--- a/pyqi/core/interfaces/optparse/output_handler.py
+++ b/pyqi/core/interfaces/optparse/output_handler.py
@@ -20,14 +20,8 @@ option_value - if the handler is tied to an output option, the value of that
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout", "Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.exception import IncompetentDeveloperError
 import os

--- a/pyqi/core/log.py
+++ b/pyqi/core/log.py
@@ -12,14 +12,8 @@ from __future__ import division
 from sys import stderr
 from datetime import datetime
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 class InvalidLoggerError(Exception):
     pass

--- a/pyqi/interfaces/__init__.py
+++ b/pyqi/interfaces/__init__.py
@@ -9,11 +9,5 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/interfaces/html/config/make_bash_completion.py
+++ b/pyqi/interfaces/html/config/make_bash_completion.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)
 from pyqi.core.interfaces.html.output_handler import newline_list_of_strings

--- a/pyqi/interfaces/html/config/make_command.py
+++ b/pyqi/interfaces/html/config/make_command.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)
 from pyqi.core.interfaces.optparse.input_handler import string_list_handler

--- a/pyqi/interfaces/html/config/make_optparse.py
+++ b/pyqi/interfaces/html/config/make_optparse.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.optparse.input_handler import command_handler
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)

--- a/pyqi/interfaces/optparse/__init__.py
+++ b/pyqi/interfaces/optparse/__init__.py
@@ -9,11 +9,5 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/interfaces/optparse/config/__init__.py
+++ b/pyqi/interfaces/optparse/config/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"

--- a/pyqi/interfaces/optparse/config/make_bash_completion.py
+++ b/pyqi/interfaces/optparse/config/make_bash_completion.py
@@ -8,13 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseUsageExample,
@@ -29,8 +24,9 @@ cmd_out_lookup = make_command_out_collection_lookup_f(CommandConstructor)
 
 usage_examples = [
     OptparseUsageExample(ShortDesc="Create a bash completion script",
-                         LongDesc="Create a bash completion script for use with a pyqi driver",
-                         Ex="%prog --command-config-module pyqi.interfaces.optparse.config --driver-name pyqi -o ~/.bash_completion.d/pyqi")
+        LongDesc="Create a bash completion script for use with a pyqi driver",
+        Ex="%prog --command-config-module pyqi.interfaces.optparse.config "
+            "--driver-name pyqi -o ~/.bash_completion.d/pyqi")
 ]
 
 inputs = [

--- a/pyqi/interfaces/optparse/config/make_command.py
+++ b/pyqi/interfaces/optparse/config/make_command.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseResult,
@@ -31,25 +25,17 @@ cmd_out_lookup = make_command_out_collection_lookup_f(CommandConstructor)
 
 usage_examples = [
     OptparseUsageExample(ShortDesc="Basic Command",
-                         LongDesc="Create a basic Command with appropriate attribution",
-                         Ex='%prog -n example -a "some author" -c "Copyright 2013, The pyqi project" -e "foo@bar.com" -l BSD --command-version "0.1" --credits "someone else","and another person" -o example.py')
+        LongDesc="Create a basic Command with appropriate attribution",
+        Ex='%prog -n example --credits "someone","and another person" -o "
+            "example.py')
 ]
 
 inputs = [
     OptparseOption(Parameter=cmd_in_lookup('name'),
                    ShortName='n'),
-    OptparseOption(Parameter=cmd_in_lookup('author'),
-                   ShortName='a'),
-    OptparseOption(Parameter=cmd_in_lookup('email'),
-                   ShortName='e'),
-    OptparseOption(Parameter=cmd_in_lookup('license'),
-                   ShortName='l'),
-    OptparseOption(Parameter=cmd_in_lookup('copyright'),
-                   ShortName='c'),
-    OptparseOption(Parameter=cmd_in_lookup('version'), Name='command-version'),
     OptparseOption(Parameter=cmd_in_lookup('credits'),
                    Handler=string_list_handler,
-                   Help='comma-separated list of other authors'),
+                   Help='comma-separated list of authors'),
     OptparseOption(Parameter=cmd_in_lookup('test_code'),
                    Type=None, Action='store_true'),
     OptparseOption(Parameter=None,

--- a/pyqi/interfaces/optparse/config/make_optparse.py
+++ b/pyqi/interfaces/optparse/config/make_optparse.py
@@ -8,18 +8,12 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.command import Command
-from pyqi.core.interfaces.optparse import (OptparseOption, OptparseUsageExample,
-    OptparseResult)
+from pyqi.core.interfaces.optparse import (OptparseOption, 
+    OptparseUsageExample, OptparseResult)
 from pyqi.core.interfaces.optparse.input_handler import (command_handler,
                                                          string_list_handler)
 from pyqi.core.interfaces.optparse.output_handler import write_list_of_strings
@@ -32,11 +26,22 @@ cmdout_lookup = make_command_out_collection_lookup_f(CommandConstructor)
 
 usage_examples = [
     OptparseUsageExample(ShortDesc="Create an optparse config template",
-                         LongDesc="Construct the beginning of an optparse configuration file based on the Parameters required by the Command.",
-                         Ex='%prog -c pyqi.commands.make_optparse.MakeOptparse -m pyqi.commands.make_optparse -a "some author" --copyright "Copyright 2013, The pyqi project" -e "foo@bar.com" -l BSD --config-version "0.1" --credits "someone else","and another person" -o pyqi/interfaces/optparse/config/make_optparse.py'),
-    OptparseUsageExample(ShortDesc="Create a different optparse config template",
-                         LongDesc="Construct the beginning of an optparse configuration file based on the Parameters required by the Command. This command corresponds to the pyqi tutorial example where a sequence_collection_summarizer command line interface is created for a SequenceCollectionSummarizer Command.",
-                         Ex='%prog -c sequence_collection_summarizer.SequenceCollectionSummarizer -m sequence_collection_summarizer -a "Greg Caporaso" --copyright "Copyright 2013, Greg Caporaso" -e "gregcaporaso@gmail.com" -l BSD --config-version 0.0.1 -o summarize_sequence_collection.py')
+        LongDesc="Construct the beginning of an optparse configuration file "
+            "based on the Parameters required by the Command.",
+        Ex='%prog -c pyqi.commands.make_optparse.MakeOptparse -m '
+            'pyqi.commands.make_optparse --credits "someone","and another '
+            'person" -o pyqi/interfaces/optparse/config/make_optparse.py'),
+    OptparseUsageExample(ShortDesc="Create a different optparse config "
+        "template",
+        LongDesc="Construct the beginning of an optparse configuration file "
+            "based on the Parameters required by the Command. This command "
+            "corresponds to the pyqi tutorial example where a "
+            "sequence_collection_summarizer command line interface is created "
+            "for a SequenceCollectionSummarizer Command.",
+        Ex='%prog '
+            '-c sequence_collection_summarizer.SequenceCollectionSummarizer '
+            '-m sequence_collection_summarizer '
+            '-o summarize_sequence_collection.py')
 ]
 
 inputs = [
@@ -45,23 +50,16 @@ inputs = [
                    Handler=command_handler),
     OptparseOption(Parameter=cmdin_lookup('command_module'),
                    ShortName='m'),
-    OptparseOption(Parameter=cmdin_lookup('author'),
-                   ShortName='a'),
-    OptparseOption(Parameter=cmdin_lookup('email'),
-                   ShortName='e'),
-    OptparseOption(Parameter=cmdin_lookup('license'),
-                   ShortName='l'),
-    OptparseOption(Parameter=cmdin_lookup('copyright')),
-    OptparseOption(Parameter=cmdin_lookup('version'), Name='config-version'),
     OptparseOption(Parameter=cmdin_lookup('credits'),
                    Handler=string_list_handler,
-                   Help='comma-separated list of other authors'),
+                   Help='comma-separated list of authors'),
     OptparseOption(Parameter=None,
                    Type='new_filepath',
                    ShortName='o',
                    Name='output-fp',
                    Required=True,
-                   Help='output filepath to store generated optparse Python configuration file')
+                   Help='output filepath to store generated optparse Python '
+                        'configuration file')
 ]
 
 outputs = [

--- a/pyqi/interfaces/optparse/config/serve_html_interface.py
+++ b/pyqi/interfaces/optparse/config/serve_html_interface.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseResult,

--- a/pyqi/interfaces/optparse/input_handler.py
+++ b/pyqi/interfaces/optparse/input_handler.py
@@ -9,13 +9,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 ## Store project/inteface specific input handlers here

--- a/pyqi/interfaces/optparse/output_handler.py
+++ b/pyqi/interfaces/optparse/output_handler.py
@@ -9,13 +9,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 ## Store project/inteface specific output handlers here

--- a/pyqi/util.py
+++ b/pyqi/util.py
@@ -10,13 +10,7 @@
 
 """Utility functionality for the pyqi project."""
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 from os import remove
 from os.path import split, splitext

--- a/scripts/pyqi
+++ b/scripts/pyqi
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi Project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 import importlib
 import textwrap

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Rob Knight", "Greg Caporaso", "Jai Ram Rideout",
                "Daniel McDonald", "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 from distutils.core import setup
 from glob import glob
@@ -62,10 +56,6 @@ setup(name='pyqi',
       license=__license__,
       description='pyqi: expose your interface',
       long_description=long_description,
-      author=__maintainer__,
-      author_email=__email__,
-      maintainer=__maintainer__,
-      maintainer_email=__email__,
       url='http://bipy.github.io/pyqi',
       packages=['pyqi',
                 'pyqi/commands',

--- a/tests/test_commands/test_code_header_generator.py
+++ b/tests/test_commands/test_code_header_generator.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
+__credits__ = ["Jai Ram Rideout", "Adam Robbins-Pianka"]
 
 from unittest import TestCase, main
 from pyqi.commands.code_header_generator import CodeHeaderGenerator
@@ -27,19 +21,15 @@ class CodeHeaderGeneratorTests(TestCase):
 
     def test_run(self):
         """Correctly generates header with and without credits."""
-        obs = self.cmd(author='bob', email='bob@bob.bob',
-                       license='very permissive license',
-                       copyright='what\'s that?', version='1.0')
+        obs = self.cmd(credits=['bob'])
         self.assertEqual(obs.keys(), ['result'])
 
         obs = obs['result']
         self.assertEqual('\n'.join(obs), exp_header1)
 
-        # With credits.
-        obs = self.cmd(author='bob', email='bob@bob.bob',
-                       license='very permissive license',
-                       copyright='what\'s that?', version='1.0',
-                       credits=['another person', 'another another person'])
+        # With more than 1 credit.
+        obs = self.cmd(credits=['bob', 'another person',
+            'another another person'])
         self.assertEqual(obs.keys(), ['result'])
 
         obs = obs['result']
@@ -49,25 +39,13 @@ class CodeHeaderGeneratorTests(TestCase):
 exp_header1 = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "bob"
-__copyright__ = "what's that?"
 __credits__ = ["bob"]
-__license__ = "very permissive license"
-__version__ = "1.0"
-__maintainer__ = "bob"
-__email__ = "bob@bob.bob"
 """
 
 exp_header2 = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "bob"
-__copyright__ = "what's that?"
 __credits__ = ["bob", "another person", "another another person"]
-__license__ = "very permissive license"
-__version__ = "1.0"
-__maintainer__ = "bob"
-__email__ = "bob@bob.bob"
 """
 
 

--- a/tests/test_commands/test_make_bash_completion.py
+++ b/tests/test_commands/test_make_bash_completion.py
@@ -18,14 +18,8 @@ from unittest import TestCase, main
 import pyqi
 from pyqi.commands.make_bash_completion import BashCompletion, _get_cfg_module
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
                "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 class BashCompletionTests(TestCase):
     def setUp(self):
@@ -105,7 +99,7 @@ outputandstuff = """_pyqi_complete()
         COMPREPLY=( $(compgen -W "--command-config-module --driver-name --output-fp" -- $cur) )
         ;;
        "make-optparse")
-        COMPREPLY=( $(compgen -W "--author --command --command-module --config-version --copyright --credits --email --license --output-fp" -- $cur) )
+        COMPREPLY=( $(compgen -W "--command --command-module --credits --output-fp" -- $cur) )
         ;;
 
       *)

--- a/tests/test_commands/test_make_command.py
+++ b/tests/test_commands/test_make_command.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
 from pyqi.commands.make_command import MakeCommand
@@ -27,9 +21,7 @@ class MakeCommandTests(TestCase):
 
     def test_run_command_code_generation(self):
         """Correctly generates stubbed out Command code."""
-        obs = self.cmd(name='Test', author='bob', email='bob@bob.bob',
-                       license='very permissive license',
-                       copyright='what\'s that?', version='1.0')
+        obs = self.cmd(name='Test', credits=['bob'])
         self.assertEqual(obs.keys(), ['result'])
 
         obs = obs['result']
@@ -37,10 +29,8 @@ class MakeCommandTests(TestCase):
 
     def test_run_test_code_generation(self):
         """Correctly generates stubbed out unit test code."""
-        obs = self.cmd(name='Test', author='bob', email='bob@bob.bob',
-                       license='very permissive license',
-                       copyright='what\'s that?', version='1.0',
-                       credits=['another person'], test_code=True)
+        obs = self.cmd(name='Test', credits=['bob', 'another person'],
+            test_code=True)
         self.assertEqual(obs.keys(), ['result'])
 
         obs = obs['result']
@@ -50,13 +40,7 @@ class MakeCommandTests(TestCase):
 exp_command_code1 = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "bob"
-__copyright__ = "what's that?"
 __credits__ = ["bob"]
-__license__ = "very permissive license"
-__version__ = "1.0"
-__maintainer__ = "bob"
-__email__ = "bob@bob.bob"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, 
     ParameterCollection)
@@ -88,13 +72,7 @@ CommandConstructor = Test"""
 exp_test_code1 = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "bob"
-__copyright__ = "what's that?"
 __credits__ = ["bob", "another person"]
-__license__ = "very permissive license"
-__version__ = "1.0"
-__maintainer__ = "bob"
-__email__ = "bob@bob.bob"
 
 from unittest import TestCase, main
 from FILL IN MODULE PATH import Test

--- a/tests/test_commands/test_make_optparse.py
+++ b/tests/test_commands/test_make_optparse.py
@@ -9,17 +9,14 @@
 #-----------------------------------------------------------------------------
 
 from __future__ import division
-from pyqi.commands.make_optparse import MakeOptparse
-from pyqi.core.command import CommandIn, ParameterCollection
+
 from unittest import TestCase, main
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+from pyqi.commands.make_optparse import MakeOptparse
+from pyqi.core.command import CommandIn, ParameterCollection
+
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 class MakeOptparseTests(TestCase):
     def setUp(self):
@@ -38,11 +35,7 @@ class MakeOptparseTests(TestCase):
 
         obs = self.cmd(**{'command_module':'foobar',
                           'command':stubby(),
-                          'author': 'bob',
-                          'email': 'bob@bob.bob',
-                          'license': 'very permissive license',
-                          'copyright': 'what\'s that?',
-                          'version': '1.0'
+                          'credits':['bob']
         })
         
         self.assertEqual(obs['result'], exp.splitlines())
@@ -50,13 +43,7 @@ class MakeOptparseTests(TestCase):
 win_text = """#!/usr/bin/env python
 from __future__ import division
 
-__author__ = "bob"
-__copyright__ = "what's that?"
 __credits__ = ["bob"]
-__license__ = "very permissive license"
-__version__ = "1.0"
-__maintainer__ = "bob"
-__email__ = "bob@bob.bob"
 
 from pyqi.core.interfaces.optparse import (OptparseUsageExample,
                                            OptparseOption, OptparseResult)

--- a/tests/test_core/test_command.py
+++ b/tests/test_core/test_command.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.command import CommandIn, CommandOut, ParameterCollection, Command

--- a/tests/test_core/test_interface.py
+++ b/tests/test_core/test_interface.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
 from pyqi.core.interface import get_command_names, get_command_config

--- a/tests/test_core/test_interfaces/test_optparse/test_init.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_init.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout", "Jose Antonio Navas Molina"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.interfaces.optparse import (OptparseResult, OptparseOption,

--- a/tests/test_core/test_interfaces/test_optparse/test_input_handler.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_input_handler.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.interfaces.optparse.input_handler import command_handler

--- a/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 import os
 import sys


### PR DESCRIPTION
Removes most of the script-level headers (version, copyright, author, etc.),
leaving only credits.  In the pyqi.**init**.py file, version is also present.
