### PR TITLE
Modify script-level headers

### DIFF
--- a/pyqi/__init__.py
+++ b/pyqi/__init__.py
@@ -8,11 +8,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Rob Knight", "Greg Caporaso", "Daniel McDonald",
                "Jai Ram Rideout", "Doug Wendel"]
-__license__ = "BSD"
 __version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/commands/__init__.py
+++ b/pyqi/commands/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Greg Caporaso",
                "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"

--- a/pyqi/commands/code_header_generator.py
+++ b/pyqi/commands/code_header_generator.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Jai Ram Rideout", "Daniel McDonald"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, 
     ParameterCollection)

--- a/pyqi/commands/make_bash_completion.py
+++ b/pyqi/commands/make_bash_completion.py
@@ -10,13 +10,8 @@
 
 from __future__ import division
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 import importlib
 from pyqi.core.command import (Command, CommandIn, CommandOut, 

--- a/pyqi/commands/make_command.py
+++ b/pyqi/commands/make_command.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, 
     ParameterCollection)

--- a/pyqi/commands/make_optparse.py
+++ b/pyqi/commands/make_optparse.py
@@ -14,14 +14,8 @@ from pyqi.core.command import (Command, CommandIn, CommandOut,
     ParameterCollection)
 from pyqi.commands.code_header_generator import CodeHeaderGenerator
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Greg Caporaso",
                "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 header_format = """from pyqi.core.interfaces.optparse import (OptparseUsageExample,
                                            OptparseOption, OptparseResult)

--- a/pyqi/commands/serve_html_interface.py
+++ b/pyqi/commands/serve_html_interface.py
@@ -10,13 +10,7 @@
 
 from __future__ import division
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.command import (Command, CommandIn, CommandOut, ParameterCollection)
 from pyqi.core.interfaces.html import start_server

--- a/pyqi/core/__init__.py
+++ b/pyqi/core/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/core/command.py
+++ b/pyqi/core/command.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import re
 from pyqi.core.log import NullLogger

--- a/pyqi/core/container.py
+++ b/pyqi/core/container.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 class ContainerError(Exception):
     pass

--- a/pyqi/core/exception.py
+++ b/pyqi/core/exception.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 class CommandError(Exception):
     pass

--- a/pyqi/core/factory.py
+++ b/pyqi/core/factory.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 def general_factory(command_constructor, usage_examples, inputs, outputs,
                     version, interface=None):

--- a/pyqi/core/interface.py
+++ b/pyqi/core/interface.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout", "Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import importlib
 from sys import exit, stderr

--- a/pyqi/core/interfaces/__init__.py
+++ b/pyqi/core/interfaces/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/core/interfaces/html/__init__.py
+++ b/pyqi/core/interfaces/html/__init__.py
@@ -8,13 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
+__credits__ = ["Evan Bolyen", "Jai Ram Rideout", "Daniel McDonald",
+    "Greg Caporaso"]
 
 import os
 import types

--- a/pyqi/core/interfaces/html/input_handler.py
+++ b/pyqi/core/interfaces/html/input_handler.py
@@ -9,11 +9,4 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
-

--- a/pyqi/core/interfaces/html/output_handler.py
+++ b/pyqi/core/interfaces/html/output_handler.py
@@ -9,13 +9,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 def newline_list_of_strings(result_key, data, option_value=None):
     """Return a string from a list of strings while appending newline"""

--- a/pyqi/core/interfaces/optparse/__init__.py
+++ b/pyqi/core/interfaces/optparse/__init__.py
@@ -8,15 +8,9 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Gavin Huttley",
                "Rob Knight", "Doug Wendel", "Jai Ram Rideout",
                "Jose Antonio Navas Molina"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 import os
 import types

--- a/pyqi/core/interfaces/optparse/input_handler.py
+++ b/pyqi/core/interfaces/optparse/input_handler.py
@@ -14,14 +14,8 @@ function(option_value)
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 def command_handler(option_value):
     """Dynamically load a Python object from a module and return an instance"""

--- a/pyqi/core/interfaces/optparse/output_handler.py
+++ b/pyqi/core/interfaces/optparse/output_handler.py
@@ -20,14 +20,8 @@ option_value - if the handler is tied to an output option, the value of that
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout", "Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.exception import IncompetentDeveloperError
 import os

--- a/pyqi/core/log.py
+++ b/pyqi/core/log.py
@@ -12,14 +12,8 @@ from __future__ import division
 from sys import stderr
 from datetime import datetime
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 class InvalidLoggerError(Exception):
     pass

--- a/pyqi/interfaces/__init__.py
+++ b/pyqi/interfaces/__init__.py
@@ -9,11 +9,5 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/interfaces/html/config/make_bash_completion.py
+++ b/pyqi/interfaces/html/config/make_bash_completion.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)
 from pyqi.core.interfaces.html.output_handler import newline_list_of_strings

--- a/pyqi/interfaces/html/config/make_command.py
+++ b/pyqi/interfaces/html/config/make_command.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)
 from pyqi.core.interfaces.optparse.input_handler import string_list_handler

--- a/pyqi/interfaces/html/config/make_optparse.py
+++ b/pyqi/interfaces/html/config/make_optparse.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.optparse.input_handler import command_handler
 from pyqi.core.interfaces.html import (HTMLInputOption, HTMLDownload, HTMLPage)

--- a/pyqi/interfaces/optparse/__init__.py
+++ b/pyqi/interfaces/optparse/__init__.py
@@ -9,11 +9,5 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"

--- a/pyqi/interfaces/optparse/config/__init__.py
+++ b/pyqi/interfaces/optparse/config/__init__.py
@@ -8,11 +8,5 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"

--- a/pyqi/interfaces/optparse/config/make_bash_completion.py
+++ b/pyqi/interfaces/optparse/config/make_bash_completion.py
@@ -8,13 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseUsageExample,

--- a/pyqi/interfaces/optparse/config/make_command.py
+++ b/pyqi/interfaces/optparse/config/make_command.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseResult,

--- a/pyqi/interfaces/optparse/config/make_optparse.py
+++ b/pyqi/interfaces/optparse/config/make_optparse.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from pyqi.core.command import Command
 from pyqi.core.interfaces.optparse import (OptparseOption, OptparseUsageExample,

--- a/pyqi/interfaces/optparse/config/serve_html_interface.py
+++ b/pyqi/interfaces/optparse/config/serve_html_interface.py
@@ -8,13 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Evan Bolyen"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Evan Bolyen"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Evan Bolyen"
-__email__ = "ebolyen@gmail.com"
 
 from pyqi.core.interfaces.optparse import (OptparseOption,
                                            OptparseResult,

--- a/pyqi/interfaces/optparse/input_handler.py
+++ b/pyqi/interfaces/optparse/input_handler.py
@@ -9,13 +9,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 ## Store project/inteface specific input handlers here

--- a/pyqi/interfaces/optparse/output_handler.py
+++ b/pyqi/interfaces/optparse/output_handler.py
@@ -9,13 +9,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 ## Store project/inteface specific output handlers here

--- a/pyqi/util.py
+++ b/pyqi/util.py
@@ -10,13 +10,7 @@
 
 """Utility functionality for the pyqi project."""
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 from os import remove
 from os.path import split, splitext

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Greg Caporaso"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Rob Knight", "Greg Caporaso", "Jai Ram Rideout",
                "Daniel McDonald", "Doug Wendel"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Greg Caporaso"
-__email__ = "gregcaporaso@gmail.com"
 
 from distutils.core import setup
 from glob import glob

--- a/tests/test_commands/test_code_header_generator.py
+++ b/tests/test_commands/test_code_header_generator.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
 from pyqi.commands.code_header_generator import CodeHeaderGenerator

--- a/tests/test_commands/test_make_bash_completion.py
+++ b/tests/test_commands/test_make_bash_completion.py
@@ -18,14 +18,8 @@ from unittest import TestCase, main
 import pyqi
 from pyqi.commands.make_bash_completion import BashCompletion, _get_cfg_module
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
                "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 class BashCompletionTests(TestCase):
     def setUp(self):

--- a/tests/test_commands/test_make_command.py
+++ b/tests/test_commands/test_make_command.py
@@ -9,13 +9,7 @@ from __future__ import division
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
 from pyqi.commands.make_command import MakeCommand

--- a/tests/test_commands/test_make_optparse.py
+++ b/tests/test_commands/test_make_optparse.py
@@ -13,13 +13,8 @@ from pyqi.commands.make_optparse import MakeOptparse
 from pyqi.core.command import CommandIn, ParameterCollection
 from unittest import TestCase, main
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
-__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel", "Greg Caporaso"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
+__credits__ = ["Daniel McDonald", "Jai Ram Rideout", "Doug Wendel",
+    "Greg Caporaso"]
 
 class MakeOptparseTests(TestCase):
     def setUp(self):

--- a/tests/test_core/test_command.py
+++ b/tests/test_core/test_command.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.command import CommandIn, CommandOut, ParameterCollection, Command

--- a/tests/test_core/test_interface.py
+++ b/tests/test_core/test_interface.py
@@ -9,14 +9,8 @@
 #-----------------------------------------------------------------------------
 from __future__ import division
 
-__author__ = "Jai Ram Rideout"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Jai Ram Rideout"
-__email__ = "jai.rideout@gmail.com"
 
 from unittest import TestCase, main
 from pyqi.core.interface import get_command_names, get_command_config

--- a/tests/test_core/test_interfaces/test_optparse/test_init.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_init.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Greg Caporaso", "Daniel McDonald", "Doug Wendel",
                "Jai Ram Rideout", "Jose Antonio Navas Molina"]
-__license__ = "BSD"
-__version__ = "0.2.0-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.interfaces.optparse import (OptparseResult, OptparseOption,

--- a/tests/test_core/test_interfaces/test_optparse/test_input_handler.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_input_handler.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 from unittest import TestCase, main
 from pyqi.core.interfaces.optparse.input_handler import command_handler

--- a/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
+++ b/tests/test_core/test_interfaces/test_optparse/test_output_handler.py
@@ -8,14 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__author__ = "Daniel McDonald"
-__copyright__ = "Copyright 2013, The pyqi project"
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
                "Jai Ram Rideout"]
-__license__ = "BSD"
-__version__ = "0.1-dev"
-__maintainer__ = "Daniel McDonald"
-__email__ = "mcdonadt@colorado.edu"
 
 import os
 import sys


### PR DESCRIPTION
Removes most of the headers (e.g., author, version, etc.), leaving only
credits.  In pyqi.init.py, version also remains.
