### PR TITLE
Add "or_print" handlers for outputs

### DIFF
--- a/pyqi/core/interfaces/optparse/output_handler.py
+++ b/pyqi/core/interfaces/optparse/output_handler.py
@@ -21,7 +21,7 @@ option_value - if the handler is tied to an output option, the value of that
 #-----------------------------------------------------------------------------
 
 __credits__ = ["Daniel McDonald", "Greg Caporaso", "Doug Wendel",
-               "Jai Ram Rideout", "Evan Bolyen"]
+               "Jai Ram Rideout", "Evan Bolyen", "Adam Robbins-Pianka"]
 
 from pyqi.core.exception import IncompetentDeveloperError
 import os
@@ -73,3 +73,26 @@ def print_string(result_key, data, option_value=None):
     A newline will be printed before the data"""
     print ""
     print data
+
+def write_or_print_string(result_key, data, option_value=None):
+    """Write a string to a file.
+
+    A newline will be added to the end of the file. If no file is supplied,
+    then the output will be printed to stdout instead.
+    """
+    if option_value is None:
+        print_string(result_key, data, option_value)
+    else:
+        write_string(result_key, data, option_value)
+
+def write_or_print_list_of_strings(result_key, data, option_value=None):
+    """Write a list of strings to a file, one per line.
+
+    A newline will be added to the end of the file. If no file is supplied,
+    then the output will be printed to stdout instead.
+    """
+    if option_value is None:
+        print_list_of_strings(result_key, data, option_value)
+    else:
+        write_list_of_strings(result_key, data, option_value)
+


### PR DESCRIPTION
For when the output file is not a required option. I have a feeling this will be a common request from pyqi developers, and IMHO should be added to the set of pyqi core output handlers
