### PR TITLE
initial workflow commit

### DIFF
--- a/pyqi/core/workflow.py
+++ b/pyqi/core/workflow.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, The BiPy Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""Perform multiple method calls, determined at runtime, on independent items
+
+Construct arbitrarily complex workflows in which the specific methods run are
+determined at runtime. These methods are applied to items that are assumed to
+be independent.
+
+As an example:
+
+class MyWorkflow(Workflow):
+    @priority(100)
+    @no_requirements
+    def wf_mul(self, item):
+        self.FinalState *= item
+
+    @priority(10)
+    @requires(Option='add_value')
+    def wf_add(self, item):
+        self.FinalState += item
+    
+    @requires(Option='sub_value', Values=[1,5,10])
+    def wf_sub(self, item):
+        self.FinalState -= item
+        self.FinalState -= self.Options['sub_value']
+
+    @priority(1000)
+    @requires(IsValid=False)
+    def wf_init(self, item):
+        self.FinalState = item
+
+# (i * i) + i - i - 5
+wf = MyWorkflow(Options={'add_value':None, 'sub_value':5})
+gen = (i for i in range(10))
+for i in wf(gen):
+    print i
+
+# (i * i) - i - 10
+wf = MyWorkflow(Options={'sub_value':10})
+gen = (i for i in range(10))
+for i in wf(gen):
+    print i
+
+# (i * i)
+wf = MyWorkflow()
+gen = (i for i in range(10))
+for i in wf(gen):
+    print i
+"""
+
+from itertools import chain
+from functools import update_wrapper
+from collections import Iterable, defaultdict
+from types import MethodType
+
+__credits__ = ["Daniel McDonald", "Tony Walters"]
+
+# thank you Flask project...
+_missing = object()
+_executed = object()
+
+class Exists(object):
+    def __contains__(self, item):
+        return True
+option_exists = Exists()
+
+def _debug_trace_wrapper(obj, f):
+    """Trace a function call"""
+    def wrapped(self, *args, **kwargs):
+        if not hasattr(obj, 'DebugTrace'):
+            raise AttributeError("%s does not have DebugTrace!" % obj.__class__)
+
+        obj.DebugTrace.append(f.__name__)
+        return f(self, *args, **kwargs)
+
+    return update_wrapper(wrapped, f)
+
+def _tag_function(f):
+    """Tag, you're it"""
+    setattr(f, '__workflowtag__', None)
+
+class priority(object):
+    """Sets a function priority"""
+    def __init__(self, Priority):
+        self.Priority = Priority
+
+    def __call__(self, f):
+        f.Priority = self.Priority
+        return f
+
+def no_requirements(f):
+    """Explicitly state that a method does not have requirements
+
+    This is necessary if you want a method to be included as a workflow
+    method
+    """
+    def decorated(self, *args, **kwargs):
+        f(self, *args, **kwargs)
+        return _executed
+    _tag_function(decorated)
+    return update_wrapper(decorated, f)
+
+class requires(object):
+    """Decorator that executes a function if requirements are met"""
+    def __init__(self, IsValid=True, Option=None, Values=_missing, 
+                 ValidData=None):
+        """
+        IsValid : execute the function if self.Failed is False
+        Option : a required option
+        Values : required values associated with an option
+        ValidData : data level requirements, this must be a function with the 
+            following signature: f(*args, **kwargs) returning True. NOTE: if
+            ValidData returns False on the first item evaluated, the decorated
+            function will be removed from the remaining workflow. 
+        """
+        # self here is the requires object
+        self.IsValid = IsValid
+        self.Option = Option
+        self.ValidData = ValidData
+
+        if Values is _missing:
+            self.Values = option_exists
+        elif not isinstance(Values, set):
+            if isinstance(Values, str):
+                self.Values = Values
+            elif isinstance(Values, Iterable):
+                self.Values = set(Values)
+            else:
+                self.Values = set([Values])
+        else:
+            self.Values = Values
+
+    def doShortCircuit(self, wrapped):
+        if self.IsValid and (wrapped.Failed and wrapped.ShortCircuit):
+            return True
+        else:
+            return False
+
+    def __call__(self, f):
+        """Wrap a function
+
+        f : the function to wrap
+        """
+        ### not sure how I feel about having multiple functions in here. 
+        ### also, the handling of Data is a bit dirty as it is now replicated
+        ### over these functions. It is ideal to keep the functions slim, thus
+        ### the multiple functions, but this could explode if not careful
+        def decorated_with_option(dec_self, *args, **kwargs):
+            """A decorated function that has an option to validate
+
+            dec_self : this is "self" for the decorated function
+            """
+            if self.doShortCircuit(dec_self):
+                return
+
+            if self.ValidData is not None:
+                if not self.ValidData(*args, **kwargs):
+                    return
+
+            s_opt = self.Option
+            ds_opts = dec_self.Options
+
+            if s_opt in ds_opts and ds_opts[s_opt] in self.Values:
+                f(dec_self, *args, **kwargs)
+                return _executed
+
+        def decorated_without_option(dec_self, *args, **kwargs):
+            """A decorated function that does not have an option to validate
+
+            dec_self : this is "self" for the decorated function
+            """
+            if self.doShortCircuit(dec_self):    
+                return
+
+            if self.ValidData is not None:
+                if not self.ValidData(*args, **kwargs):
+                    return
+
+            f(dec_self, *args, **kwargs)
+            return _executed
+
+        _tag_function(decorated_with_option)
+        _tag_function(decorated_without_option)
+
+        if self.Option is None:
+            return update_wrapper(decorated_without_option, f)
+        else:
+            return update_wrapper(decorated_with_option, f)
+
+class Workflow(object):
+    """Arbitrary worflow support structure"""
+
+    def __init__(self, ShortCircuit=True, Debug=False, Options=None, **kwargs):
+        """Build thy self
+
+        ShortCiruit : if True, enables ignoring function groups when a given
+            item has failed
+        Debug : Enable debug mode
+        Options : runtime options, {'option':values}
+        kwargs : Additional arguments will be added to self
+
+        All workflow methods (i.e., those starting with "wk_") must be decorated
+        by either "no_requirements" or "requires". This ensures that the methods
+        support the automatic workflow determination mechanism.
+        """
+        if Options is None:
+            self.Options = {}
+        else:
+            self.Options = Options
+
+        ### collections.Counter instead?
+        self.Stats = defaultdict(int)
+        self.ShortCircuit = ShortCircuit
+        self.Failed = False
+        self.Debug = Debug
+
+        # Provide some flexibility to subclasses on how FinalState is defined
+        if not hasattr(self, 'FinalState'):
+            self.FinalState = None
+
+        if self.Debug:
+            self.DebugTrace = []
+
+        for k,v in kwargs.iteritems():
+            if hasattr(self, k):
+                raise AttributeError("%s exists in self!" % k)
+            setattr(self, k, v)
+
+        for f in self._all_wf_methods():
+            if not hasattr(f, '__workflowtag__'):
+                raise AttributeError("%s isn't a workflow method!" % f.__name__)
+
+        self._sanity_check()
+        self._stage_state()
+        self._setup_debug()
+    
+    def _setup_debug(self):
+        """Wrap all methods with debug trace support"""
+        if not self.Debug:
+            return
+       
+        _ignore = set(['_get_workflow','_all_wf_methods','_sanity_check',
+                       '_stage_state'])
+        
+        for attrname in dir(self):
+            if attrname.startswith('__'):
+                continue
+            if attrname in _ignore:    
+                continue
+
+            attr = getattr(self, attrname)
+
+            if isinstance(attr, MethodType):
+                setattr(self, attrname, _debug_trace_wrapper(self, attr))
+
+    def _stage_state(self):
+        """Stage any additional data necessary for the workflow
+        
+        This does not need to be overloaded
+        """
+        pass
+
+    def _sanity_check(self):
+        """Perform a sanity check on self"""
+        raise NotImplementedError("Must implement a sanity check!")
+
+    def _all_wf_methods(self, default_priority=0):
+        """Get all workflow methods
+        
+        Methods are sorted by priority
+        """
+        methods = [getattr(self, f) for f in dir(self) if f.startswith('wf_')]
+        key = lambda x: getattr(x, 'Priority', default_priority)
+        methods_sorted = sorted(methods, key=key, reverse=True)
+
+        if methods_sorted[0] != self.wf_SETUP_DEBUG_TRACE:
+            name = methods_sorted[0].__name__
+            debug_prio = self.wf_SETUP_DEBUG_TRACE.Priority
+
+            raise AttributeError("Method %s has a higher priority than the "
+                                 "debug trace method. Please set its priority "
+                                 "below %d." % (name, debug_prio))
+        
+        if not self.Debug:
+            methods_sorted.pop(0)
+        
+        return methods_sorted
+
+    def _get_workflow(self, it):
+        """Get the methods executed, sorted by priority"""
+        # save state
+        shortcircuit_state = self.ShortCircuit
+        self.ShortCircuit = False
+        stats = self.Stats.copy()
+
+        peek = it.next()
+        executed = [f for f in self._all_wf_methods() if f(peek) is _executed]
+
+        # restore state
+        self.ShortCircuit = shortcircuit_state
+        self.Stats = stats
+        generator_reset = chain([peek], it)
+
+        return generator_reset, executed
+
+    @priority(99999999)
+    @no_requirements
+    def wf_SETUP_DEBUG_TRACE(self, item):
+        self.DebugTrace = []
+
+    def __call__(self, it, success_callback=None, fail_callback=None):
+        """Operate on all the data
+
+        it : an iterator
+        success_callback : method to call on a successful item prior to 
+            yielding
+        fail_callback : method to call on a failed item prior to yielding
+        """
+        if success_callback is None:
+            success_callback = lambda x: x.FinalState
+
+        it, workflow = self._get_workflow(it)
+        
+        for item in it:
+            self.Failed = False
+
+            for f in workflow:
+                f(item)
+
+            if self.Failed: 
+                if fail_callback is not None:
+                    yield fail_callback(self)
+            else:
+                yield success_callback(self)

--- a/tests/test_core/test_workflow.py
+++ b/tests/test_core/test_workflow.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, The BiPy Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from itertools import izip
+from pyqi.core.workflow import (Workflow, requires, priority,
+        no_requirements)
+from unittest import TestCase, main
+
+__credits__ = ["Daniel McDonald"]
+
+def construct_iterator(**kwargs):
+    """make an iterator for testing purposes"""
+    to_gen = []
+    for k in sorted(kwargs):
+        if k.startswith('iter'):
+            to_gen.append(kwargs[k])
+    if len(to_gen) == 1:
+        return (x for x in to_gen[0])
+    else:
+        return izip(*to_gen)
+
+class MockWorkflow(Workflow):
+    def _sanity_check(self):
+        pass
+
+    @priority(90)
+    @requires(Option='A', Values=True)
+    def wf_groupA(self, item):
+        self.methodA1(item)
+        self.methodA2(item)
+
+    @requires(Option='B', Values=True)
+    def wf_groupB(self, item):
+        self.methodB1(item)
+        self.methodB2(item)
+   
+    @priority(10)
+    @requires(Option='C', Values=True)
+    def wf_groupC(self, item):
+        self.methodC1(item)
+        self.methodC2(item)
+
+    @requires(IsValid=False) # always execute
+    def methodA1(self, item):
+        name = 'A1'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+    def methodA2(self, item):
+        name = 'A2'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+    @requires(IsValid=False)
+    def methodB1(self, item):
+        name = 'B1'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+            self.FinalState = 'failed'
+        else:
+            self.FinalState = (name, item)
+
+    @requires(Option='foo', Values=[1,2,3])
+    def methodB2(self, item):
+        name = 'B2'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+            self.FinalState = 'failed'
+        else:
+            self.FinalState = (name, item)
+
+    @no_requirements
+    def methodC1(self, item):
+        name = 'C1'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+    @requires(IsValid=True, Option='C2', Values=[1,2,3])
+    def methodC2(self, item):
+        name = 'C2'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+class WorkflowTests(TestCase):
+    def setUp(self):
+        self.obj_short = MockWorkflow(Options={'A':True, 'C':True})
+        self.obj_debug = MockWorkflow(Debug=True, Options={'A':True, 'C':True})
+        self.obj_noshort = MockWorkflow(ShortCircuit=False, Options=\
+                                                              {'A':True, 
+                                                               'C':True})
+   
+    def test_untagged_wf_method(self):
+        class WFTest(Workflow):
+            @no_requirements
+            def wf_1(self):
+                pass
+            def wf_2(self):
+                pass
+
+        with self.assertRaises(AttributeError):
+            _ = WFTest()
+
+    def test_get_workflow_debug(self):
+        gen = construct_iterator(**{'iter_x':[1,2,3,4,5]})
+        exp_wf = [self.obj_debug.wf_SETUP_DEBUG_TRACE, self.obj_debug.wf_groupA,
+                  self.obj_debug.wf_groupC]
+        obs_gen, obs_wf = self.obj_debug._get_workflow(gen)
+
+        self.assertEqual(obs_wf, exp_wf)
+        self.assertEqual(list(obs_gen), [1,2,3,4,5])
+        
+        self.assertEqual(self.obj_debug.Stats, {})
+        self.assertTrue(self.obj_debug.ShortCircuit)
+    
+    def test_debug_trace(self):
+        gen = construct_iterator(**{'iter_x':[1,2,3,4,5]})
+        obj = self.obj_debug(gen)
+        
+        exp = ('C1',1)
+        obs = obj.next()
+        self.assertEqual(obs, exp)
+
+        exp = ['wf_groupA', 
+               'methodA1',
+               'methodA2',
+               'wf_groupC',
+               'methodC1',
+               'methodC2']
+        obs = self.obj_debug.DebugTrace
+        self.assertEqual(obs, exp)
+        
+    def test_get_workflow(self):
+        gen = construct_iterator(**{'iter_x':[1,2,3,4,5]})
+        exp_wf = [self.obj_short.wf_groupA, self.obj_short.wf_groupC]
+        obs_gen, obs_wf = self.obj_short._get_workflow(gen)
+
+        self.assertEqual(obs_wf, exp_wf)
+        self.assertEqual(list(obs_gen), [1,2,3,4,5])
+        
+        self.assertEqual(self.obj_short.Stats, {})
+        self.assertTrue(self.obj_short.ShortCircuit)
+    
+    def test_init(self):
+        self.assertEqual(self.obj_short.Options, {'A':True, 'C':True})
+        self.assertEqual(self.obj_short.Stats, {})
+        self.assertTrue(self.obj_short.ShortCircuit)
+        self.assertEqual(self.obj_noshort.Options, {'A':True, 'C':True})
+        self.assertEqual(self.obj_noshort.Stats, {})
+        self.assertFalse(self.obj_noshort.ShortCircuit)
+
+    def test_all_wf_methods(self):
+        # note on priority: groupA:90, groupC:10, groupB:0 (default)
+        exp = [self.obj_short.wf_groupA, self.obj_short.wf_groupC,
+               self.obj_short.wf_groupB]
+        obs = self.obj_short._all_wf_methods()
+        self.assertEqual(obs, exp)
+
+    def test_call_AC_no_fail(self):
+        single_iter = construct_iterator(**{'iter_x':[1,2,3,4,5]})
+        sf = lambda x: x.FinalState # success function
+        
+        exp_stats = {'A1':5, 'A2':5, 'C1':5}
+        # C2 isn't executed as its requirements aren't met in the Options
+        exp_result = [('C1',1), ('C1',2), ('C1',3), ('C1',4), ('C1', 5)]
+
+        obs_result = list(self.obj_short(single_iter, sf, None))
+
+        self.assertEqual(obs_result, exp_result)
+        self.assertEqual(self.obj_short.Stats, exp_stats)
+
+    def test_call_AC_fail(self):
+        single_iter = construct_iterator(**{'iter_x':[1,2,'fail A2',4,5]})
+        sf = lambda x: x.FinalState # success function
+        ff = lambda x: x.FinalState # failed function
+        
+        exp_stats = {'A1':5, 'A2':5, 'C1':4, 'C2':4}
+
+        self.obj_short.Options['C2'] = 1
+        # pass in a failed callback to capture the result, and pause execution
+        gen = self.obj_short(single_iter, sf, ff)
+
+        r1 = gen.next()
+        self.assertEqual(r1, ('C2', 1))
+        self.assertFalse(self.obj_short.Failed)
+
+        r2 = gen.next()
+        self.assertEqual(r2, ('C2', 2))
+        self.assertFalse(self.obj_short.Failed)
+        
+        r3 = gen.next()
+        self.assertEqual(self.obj_short.FinalState, ('A2', 'fail A2'))
+        self.assertTrue(self.obj_short.Failed)
+        self.assertEqual(r3, ('A2', 'fail A2'))
+
+        r4 = gen.next()
+        self.assertEqual(r4, ('C2', 4))
+        self.assertFalse(self.obj_short.Failed)
+        
+        r5 = gen.next()
+        self.assertEqual(r5, ('C2', 5))
+        self.assertFalse(self.obj_short.Failed)
+
+        self.assertEqual(self.obj_short.Stats, exp_stats)
+
+    def test_call_AC_fail_noshort(self):
+        single_iter = construct_iterator(**{'iter_x':[1,2,'fail A2',4,5]})
+        sf = lambda x: x.FinalState # success function
+        ff = lambda x: x.FinalState # failed function
+        
+        exp_stats = {'A1':5, 'A2':5, 'C1':5}
+
+        # pass in a failed callback to capture the result, and pause execution
+        gen = self.obj_noshort(single_iter, sf, ff)
+
+        r1 = gen.next()
+        self.assertEqual(r1, ('C1', 1))
+        self.assertFalse(self.obj_noshort.Failed)
+
+        r2 = gen.next()
+        self.assertEqual(r2, ('C1', 2))
+        self.assertFalse(self.obj_noshort.Failed)
+        
+        r3 = gen.next()
+        self.assertEqual(self.obj_noshort.FinalState, ('C1', 'fail A2'))
+        self.assertTrue(self.obj_noshort.Failed)
+
+        r4 = gen.next()
+        self.assertEqual(r4, ('C1', 4))
+        self.assertFalse(self.obj_noshort.Failed)
+        
+        r5 = gen.next()
+        self.assertEqual(r5, ('C1', 5))
+        self.assertFalse(self.obj_noshort.Failed)
+
+        self.assertEqual(self.obj_noshort.Stats, exp_stats)
+
+class MockWorkflowReqTest(Workflow):
+    def _sanity_check(self):
+        pass
+
+    @priority(5)
+    @requires(ValidData=lambda x: x < 3)
+    def wf_needs_data(self, item):
+        name = 'needs_data'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+    @priority(10)
+    @no_requirements
+    def wf_always_run(self, item):
+        name = 'always_run'
+        self.Stats[name] += 1
+        if item == 'fail %s' % name:
+            self.Failed = True
+        self.FinalState = (name, item)
+
+class RequiresTests(TestCase):
+    def test_validdata(self):
+        obj = MockWorkflowReqTest()
+        single_iter = construct_iterator(**{'iter_x':[1,2,3,4,5]})
+        
+        exp_stats = {'needs_data':2, 'always_run':5}
+        # C2 isn't executed as its requirements aren't met in the Options
+        exp_result = [('needs_data',1), ('needs_data',2), ('always_run',3), 
+                      ('always_run',4), ('always_run', 5)]
+
+        obs_result = list(obj(single_iter))
+
+        self.assertEqual(obs_result, exp_result)
+        self.assertEqual(obj.Stats, exp_stats)
+
+    def test_methodb1(self):
+        obj = MockWorkflow()
+        obj.methodB1('test')
+        self.assertEqual(obj.FinalState, ('B1', 'test'))
+        self.assertFalse(obj.Failed)
+        
+        # methodb1 executes regardless of if self.Failed
+        obj.Failed = True
+        obj.methodB1('test 2')
+        self.assertEqual(obj.FinalState, ('B1', 'test 2'))
+
+        obj.Failed = False
+        obj.methodB1('fail B1')
+        self.assertEqual(obj.FinalState, 'failed')
+       
+        self.assertEqual(obj.Stats, {'B1':3})
+
+    def test_methodb2_accept(self):
+        # methodb2 is setup to be valid when foo is in [1,2,3], make sure we
+        # can execute
+        obj = MockWorkflow(Options={'foo':1})
+        obj.methodB2('test')
+        self.assertEqual(obj.FinalState, ('B2', 'test'))
+        self.assertEqual(obj.Stats, {'B2':1})
+
+        # methodb2 will not execute if self.Failed
+        obj.Failed = True
+        obj.methodB2('test 2')
+        self.assertEqual(obj.FinalState, ('B2', 'test'))
+        self.assertEqual(obj.Stats, {'B2':1})
+
+    def test_methodb2_ignore(self):
+        # methodb2 is setup to be valid when foo is in [1, 2, 3], make sure
+        # we do not execute
+        obj = MockWorkflow(Options={'foo':'bar'})
+        obj.methodB2('test')
+        self.assertEqual(obj.FinalState, None)
+        self.assertEqual(obj.Stats, {})
+
+class PriorityTests(TestCase):
+    def test_dec(self):
+        @priority(10)
+        def foo(x,y,z):
+            """doc check"""
+            return x+y+z
+
+        self.assertEqual(foo.Priority, 10)
+        self.assertEqual(foo.__name__, 'foo')
+        self.assertEqual(foo.__doc__, 'doc check')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Initial `Workflow` object to support the refactoring of split libraries. It is likely there needs to be some expansion of the nomenclature and surrounding documentation. 

The basic idea is that a workflow consists of a bunch of individual methods. These methods can be grouped if so pleased. Not all of the methods are necessary at runtime, depending on the options specified. Only those methods whose requirements are satisfied are executed. Methods in the workflow can be short circuited if a prior method sets `Failed` to `True`.

Method order, or method group order, can be set using the priority decorator.

`requires` supports at this time look up of specific options and values, as well as an arbitrary function that can check if the data has specific properties (e.g., in the case of split libraries, whether `item` has quality scores or not). 

This perhaps is still a bit to meta. I have a very limited split libraries `Workflow` with a complementary pyqi `Command` but those are a few more days out.

The more this gets developed, the more I think this object can fit in for many scripts in QIIME, including bdiv and OTU picking. This centralizes and formalizes a lot of common logic (i.e., do this, then this, then this if condition xyz, then this if condition foo, etc). 

There is some relatively easy to get at data level parallelism as well here whereby the parallelism can be pushed into the data generators used. Task level would be possible too, although there would be a lot of overhead and the GIL would likely get in the way.  Optionally, this object could be "parallel" aware pretty easily too if the `__call__` method paid respect to, say, a process `Rank`. The benefit being that the data generators are agnostic to the number of processors, but generalizing parallelism here could get touchy. 
